### PR TITLE
Fix type declarations: Use export instead of module.exports

### DIFF
--- a/src/aba-validation.ts
+++ b/src/aba-validation.ts
@@ -1,19 +1,17 @@
 "use strict";
-module.exports = {
-	validate: (routingNumber: string) => {
-		const match = routingNumber.match(/^\s*([\d]{9})\s*$/);
-		if (!match) {
-			return false;
-		}
-
-		const weights = [3, 7 ,1];
-		const aba = match[1];
-
-		let sum = 0;
-		for (let i=0 ; i<9 ; ++i) {
-			sum += +aba.charAt(i) * weights[i % 3];
-		}
-
-		return (sum !== 0 && sum % 10 === 0);
+export function validate(routingNumber: string): boolean {
+	const match = routingNumber.match(/^\s*([\d]{9})\s*$/);
+	if (!match) {
+		return false;
 	}
-};
+
+	const weights = [3, 7 ,1];
+	const aba = match[1];
+
+	let sum = 0;
+	for (let i=0 ; i<9 ; ++i) {
+		sum += +aba.charAt(i) * weights[i % 3];
+	}
+
+	return (sum !== 0 && sum % 10 === 0);
+}


### PR DESCRIPTION
Type definitions are not generated when using module.exports, see
https://github.com/Microsoft/TypeScript/issues/11451

To fix that, used export directly on the main ts file.