### PR TITLE
Fix browser file path on pkg.json using incorrectly a - instead of a .

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/JamesEggers1/node-ABAValidator.git"
   },
   "main": "./dist/aba-validation",
-  "browser": "./dist/aba-validation-min.js",
+  "browser": "./dist/aba-validation.min.js",
   "types": "./dist/aba-validation.d.ts",
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
Looks like the name off the file is just incorrect, the minify script right below this change shows

```
 "minify": "uglifyjs --compress --output dist/aba-validation.min.js -- dist/aba-validation.js"
```

so the file name for browser should use a `.` instead of a `-`.

This was causing issues when trying to use this module on a browser environment.